### PR TITLE
Replace Leave-VsDevShell with Exit-VsDevShell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,16 +6,21 @@ Guidance for AI agents working in this repository.
 
 `VsDevShell` is a small PowerShell module that lets you enter a Visual Studio Developer environment **from PowerShell** by importing the environment variables that `VsDevCmd.bat` would normally set.
 
-It exports two functions:
+It exports these public functions:
 
 - `Enter-VsDevShell`: applies the Visual Studio developer environment variables to the current PowerShell process.
+- `Leave-VsDevShell`: restores the pre-enter environment values captured by `Enter-VsDevShell`.
 - `Get-VsDevEnv`: computes and returns the set of environment variables that would change.
+- `Export-VsDevEnv`: writes the computed env delta to a standard `.env` file (UTF-8 no BOM), optionally updating an existing file.
+- `Import-VsDevEnv`: parses a `.env` file back into a `VsDevEnv` (ordered hashtable) that can be piped into `Enter-VsDevShell`.
 
 ## Repo layout
 
-- `VsDevShell/VsDevShell.psd1`: module manifest (exports `Enter-VsDevShell` and `Get-VsDevEnv`).
+- `VsDevShell/VsDevShell.psd1`: module manifest (exports `Enter-VsDevShell`, `Leave-VsDevShell`, `Get-VsDevEnv`, `Export-VsDevEnv`, `Import-VsDevEnv`).
 - `VsDevShell/VsDevShell.psm1`: implementation.
-- `README.md`: minimal usage.
+- `tests/`: Pester tests.
+- `skills/`: agent skills documentation.
+- `README.md`: usage examples.
 
 ## How it works (implementation notes)
 
@@ -33,12 +38,41 @@ It exports two functions:
 
 5. Captures the `set` output, compares it against the current PowerShell environment, and returns an ordered hashtable of **only the variables that changed**.
 
-`Enter-VsDevShell` calls `Get-VsDevEnv` and applies the returned variables using `[System.Environment]::SetEnvironmentVariable(key, value)`.
+It also includes variables that were present before but are not present in the `VsDevCmd.bat` output (returned with a `$null` value to indicate “unset”).
+
+`Enter-VsDevShell`:
+
+- Has multiple parameter sets:
+   - Computes and applies a VS dev env delta (default) by calling `Get-VsDevEnv`.
+   - Applies a precomputed delta object (`[IDictionary]`) from the pipeline.
+   - Applies a standard `.env` file via `-EnvFilePath` (imports then applies).
+- Applies variables using `[System.Environment]::SetEnvironmentVariable(key, value)`.
+- Captures a pre-enter snapshot for the keys it is about to change in `$global:VsDevShellState`.
+- Refuses to “enter” again while active unless `-Force` is provided.
+
+`Leave-VsDevShell`:
+
+- Restores environment variables from `$global:VsDevShellState.PreEnv`.
+- Supports `-EnvFilePath` to restore only the keys listed in that `.env` file.
+- Clears the saved global state when fully restored.
+
+`Export-VsDevEnv`:
+
+- Can compute a delta (by calling `Get-VsDevEnv`) or accept one via the pipeline (`-EnvDelta`).
+- Writes a standard `.env` file (UTF-8 no BOM).
+- `-Mode Create` fails if the file exists; `-Mode Update` preserves unrelated lines and only replaces keys being exported.
+- `-PathMode` controls how `PATH` is handled (`Full`, `Skip`, `GitHubPath`).
+
+`Import-VsDevEnv`:
+
+- Parses `NAME=VALUE` lines (with optional quoting).
+- Unescapes the module’s exported escape sequences.
+- Treats `NAME=""` as `$null` (“unset” convention).
 
 Notes:
 
 - `AppPlatform` is currently accepted as a parameter but not used to build `VsDevCmd.bat` arguments.
-- The module sets `VSCMD_SKIP_SENDTELEMETRY=1` before running `VsDevCmd.bat`.
+- The module sets `VSCMD_SKIP_SENDTELEMETRY=1` and `VSCMD_BANNER_SHELL_NAME_ALT=...` for the `VsDevCmd.bat` invocation (without mutating the caller's environment).
 - The environment changes apply to the current PowerShell process (and child processes started after). They do not persist system-wide.
 
 ## Usage (manual verification)
@@ -53,7 +87,10 @@ See available parameters:
 
 ```powershell
 Get-Help Enter-VsDevShell -Full
+Get-Help Leave-VsDevShell -Full
 Get-Help Get-VsDevEnv -Full
+Get-Help Export-VsDevEnv -Full
+Get-Help Import-VsDevEnv -Full
 ```
 
 Compute environment changes without applying:
@@ -68,6 +105,22 @@ Enter the developer shell in the current session:
 ```powershell
 Enter-VsDevShell x64
 cl.exe /?
+```
+
+Export/import/apply pipeline:
+
+```powershell
+$envFile = Join-Path $PWD 'vsdev.env'
+Get-VsDevEnv -Arch x64 -HostArch x64 |
+   Export-VsDevEnv -Path $envFile -Mode Update -PassThru |
+   Import-VsDevEnv |
+   Enter-VsDevShell
+```
+
+Run tests:
+
+```powershell
+Invoke-Pester -Path .\tests
 ```
 
 ## Requirements / assumptions
@@ -85,7 +138,7 @@ cl.exe /?
 
 ## Making changes (guardrails)
 
-- Keep the public API stable (`Enter-VsDevShell`, `Get-VsDevEnv`) unless explicitly asked to change it.
+- Keep the public API stable (`Enter-VsDevShell`, `Leave-VsDevShell`, `Get-VsDevEnv`, `Export-VsDevEnv`, `Import-VsDevEnv`) unless explicitly asked to change it.
 - Prefer changes that still allow `Import-Module` to succeed even when Visual Studio is not installed (fail only when commands are invoked).
 - Avoid adding new dependencies; this module is intended to be lightweight.
 - If you add parameters, ensure they are forwarded correctly to `VsDevCmd.bat` and are covered by a simple manual verification snippet in this file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,14 @@ Guidance for AI agents working in this repository.
 It exports these public functions:
 
 - `Enter-VsDevShell`: applies the Visual Studio developer environment variables to the current PowerShell process.
-- `Leave-VsDevShell`: restores the pre-enter environment values captured by `Enter-VsDevShell`.
+- `Exit-VsDevShell`: restores the pre-enter environment values captured by `Enter-VsDevShell`.
 - `Get-VsDevEnv`: computes and returns the set of environment variables that would change.
 - `Export-VsDevEnv`: writes the computed env delta to a standard `.env` file (UTF-8 no BOM), optionally updating an existing file.
 - `Import-VsDevEnv`: parses a `.env` file back into a `VsDevEnv` (ordered hashtable) that can be piped into `Enter-VsDevShell`.
 
 ## Repo layout
 
-- `VsDevShell/VsDevShell.psd1`: module manifest (exports `Enter-VsDevShell`, `Leave-VsDevShell`, `Get-VsDevEnv`, `Export-VsDevEnv`, `Import-VsDevEnv`).
+- `VsDevShell/VsDevShell.psd1`: module manifest (exports `Enter-VsDevShell`, `Exit-VsDevShell`, `Get-VsDevEnv`, `Export-VsDevEnv`, `Import-VsDevEnv`).
 - `VsDevShell/VsDevShell.psm1`: implementation.
 - `tests/`: Pester tests.
 - `skills/`: agent skills documentation.
@@ -50,7 +50,7 @@ It also includes variables that were present before but are not present in the `
 - Captures a pre-enter snapshot for the keys it is about to change in `$global:VsDevShellState`.
 - Refuses to “enter” again while active unless `-Force` is provided.
 
-`Leave-VsDevShell`:
+`Exit-VsDevShell`:
 
 - Restores environment variables from `$global:VsDevShellState.PreEnv`.
 - Supports `-EnvFilePath` to restore only the keys listed in that `.env` file.
@@ -87,7 +87,7 @@ See available parameters:
 
 ```powershell
 Get-Help Enter-VsDevShell -Full
-Get-Help Leave-VsDevShell -Full
+Get-Help Exit-VsDevShell -Full
 Get-Help Get-VsDevEnv -Full
 Get-Help Export-VsDevEnv -Full
 Get-Help Import-VsDevEnv -Full
@@ -138,7 +138,7 @@ Invoke-Pester -Path .\tests
 
 ## Making changes (guardrails)
 
-- Keep the public API stable (`Enter-VsDevShell`, `Leave-VsDevShell`, `Get-VsDevEnv`, `Export-VsDevEnv`, `Import-VsDevEnv`) unless explicitly asked to change it.
+- Keep the public API stable (`Enter-VsDevShell`, `Exit-VsDevShell`, `Get-VsDevEnv`, `Export-VsDevEnv`, `Import-VsDevEnv`) unless explicitly asked to change it.
 - Prefer changes that still allow `Import-Module` to succeed even when Visual Studio is not installed (fail only when commands are invoked).
 - Avoid adding new dependencies; this module is intended to be lightweight.
 - If you add parameters, ensure they are forwarded correctly to `VsDevCmd.bat` and are covered by a simple manual verification snippet in this file.

--- a/README.md
+++ b/README.md
@@ -7,18 +7,103 @@ Install-Module VsDevShell
 Enter-VsDevShell x64
 ```
 
+Restore the original environment:
+
+```powershell
+Leave-VsDevShell
+```
+
 That's it! Use `Get-Help Enter-VsDevShell` to find all available options.
+
+## Compute without applying
+
+Get the environment delta (only variables that would change):
+
+```powershell
+$delta = Get-VsDevEnv -Arch x64 -HostArch x64
+$delta.Keys | Sort-Object | Select-Object -First 20
+```
 
 ## Export as dotenv (.env)
 
-Get the environment delta as dotenv text:
+Write the environment delta to disk as a `.env` file:
 
 ```powershell
-Get-VsDevEnv x64 -AsDotEnv
+Export-VsDevEnv -Arch x64 -HostArch x64 -Path .\vsdev.env
 ```
 
-Write it to disk as a `.env` file:
+Update an existing `.env` file in-place (replaces only the exported keys; preserves other lines):
 
 ```powershell
-Get-VsDevEnv x64 -DotEnvPath .\.env
+Export-VsDevEnv -Arch x64 -HostArch x64 -Path .\vsdev.env -Mode Update
+```
+
+Fail if the target file already exists:
+
+```powershell
+Export-VsDevEnv -Arch x64 -HostArch x64 -Path .\vsdev.env -Mode Create
+```
+
+## Import and apply
+
+Import a previously exported `.env` delta and apply it to the current PowerShell session:
+
+```powershell
+Import-VsDevEnv .\vsdev.env | Enter-VsDevShell
+```
+
+This is useful when you want to generate the delta in one step/process and apply it later in another.
+
+Fully piped chain (compute → export → import → apply):
+
+```powershell
+Get-VsDevEnv -Arch x64 -HostArch x64 |
+	Export-VsDevEnv -Path .\vsdev.env -Mode Update -PassThru |
+	Import-VsDevEnv |
+	Enter-VsDevShell
+```
+
+Apply an existing `.env` file directly (shortcut for `Import-VsDevEnv ... | Enter-VsDevShell`):
+
+```powershell
+Enter-VsDevShell -EnvFilePath .\vsdev.env
+```
+
+## GitHub Actions example
+
+In GitHub Actions, `$env:GITHUB_ENV` is a UTF-8 no-BOM file containing `NAME=VALUE` lines.
+You can update it so later steps inherit the VS dev environment:
+
+```powershell
+Export-VsDevEnv -Arch x64 -HostArch x64 -Path $env:GITHUB_ENV -Mode Update
+```
+
+If you also want to use `$env:GITHUB_PATH` for PATH updates (when it is available), use:
+
+```powershell
+Export-VsDevEnv -Arch x64 -HostArch x64 -Path $env:GITHUB_ENV -Mode Update -PathMode GitHubPath
+```
+
+Apply an existing env file (like `$env:GITHUB_ENV`) to the current PowerShell session:
+
+```powershell
+Enter-VsDevShell -EnvFilePath $env:GITHUB_ENV
+```
+
+Pipeline form:
+
+```powershell
+Get-Item -Path $env:GITHUB_ENV | Enter-VsDevShell
+```
+
+Restore only the keys listed in an env file (using the saved pre-enter snapshot):
+
+```powershell
+Leave-VsDevShell -EnvFilePath $env:GITHUB_ENV
+```
+
+Pipeline form:
+
+```powershell
+Get-Item -Path $env:GITHUB_ENV | Leave-VsDevShell
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Enter-VsDevShell x64
 Restore the original environment:
 
 ```powershell
-Leave-VsDevShell
+Exit-VsDevShell
 ```
 
 That's it! Use `Get-Help Enter-VsDevShell` to find all available options.
@@ -99,11 +99,11 @@ Get-Item -Path $env:GITHUB_ENV | Enter-VsDevShell
 Restore only the keys listed in an env file (using the saved pre-enter snapshot):
 
 ```powershell
-Leave-VsDevShell -EnvFilePath $env:GITHUB_ENV
+Exit-VsDevShell -EnvFilePath $env:GITHUB_ENV
 ```
 
 Pipeline form:
 
 ```powershell
-Get-Item -Path $env:GITHUB_ENV | Leave-VsDevShell
+Get-Item -Path $env:GITHUB_ENV | Exit-VsDevShell
 ```

--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@ Enter-VsDevShell x64
 ```
 
 That's it! Use `Get-Help Enter-VsDevShell` to find all available options.
+
+## Export as dotenv (.env)
+
+Get the environment delta as dotenv text:
+
+```powershell
+Get-VsDevEnv x64 -AsDotEnv
+```
+
+Write it to disk as a `.env` file:
+
+```powershell
+Get-VsDevEnv x64 -DotEnvPath .\.env
+```

--- a/VsDevShell/VsDevShell.psd1
+++ b/VsDevShell/VsDevShell.psd1
@@ -8,7 +8,7 @@
 RootModule = 'VsDevShell.psm1'
 
 # Version number of this module.
-ModuleVersion = '2025.1.0'
+ModuleVersion = '2026.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'
@@ -65,7 +65,7 @@ CLRVersion = '4.0'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = @('Enter-VsDevShell', 'Get-VsDevEnv')
+FunctionsToExport = @('Enter-VsDevShell', 'Leave-VsDevShell', 'Get-VsDevEnv', 'Export-VsDevEnv', 'Import-VsDevEnv')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/VsDevShell/VsDevShell.psd1
+++ b/VsDevShell/VsDevShell.psd1
@@ -65,7 +65,7 @@ CLRVersion = '4.0'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = @('Enter-VsDevShell', 'Leave-VsDevShell', 'Get-VsDevEnv', 'Export-VsDevEnv', 'Import-VsDevEnv')
+FunctionsToExport = @('Enter-VsDevShell', 'Exit-VsDevShell', 'Get-VsDevEnv', 'Export-VsDevEnv', 'Import-VsDevEnv')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/VsDevShell/VsDevShell.psm1
+++ b/VsDevShell/VsDevShell.psm1
@@ -572,7 +572,7 @@ function Enter-VsDevShell
 
     process {
         if ($global:VsDevShellState -and -not $Force) {
-            throw "VsDevShell is already active in this session. Call Leave-VsDevShell first (or use -Force to overwrite the saved state)."
+            throw "VsDevShell is already active in this session. Call Exit-VsDevShell first (or use -Force to overwrite the saved state)."
         }
 
         if ($Force -and $global:VsDevShellState) {
@@ -607,7 +607,7 @@ function Enter-VsDevShell
     }
 }
 
-function Leave-VsDevShell
+function Exit-VsDevShell
 {
     [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Medium', DefaultParameterSetName='All')]
     param(

--- a/VsDevShell/VsDevShell.psm1
+++ b/VsDevShell/VsDevShell.psm1
@@ -81,6 +81,132 @@ function ConvertTo-VsDotEnvValue
     '"' + $escaped + '"'
 }
 
+function ConvertFrom-VsDotEnvValue
+{
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [string] $Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $trimmed = $Value.Trim()
+
+    # Convention for this module: NAME="" means "unset" (round-trips $null from Get-VsDevEnv/Export-VsDevEnv)
+    if ($trimmed -eq '""') {
+        return $null
+    }
+    if ($trimmed.Length -ge 2 -and $trimmed.StartsWith('"') -and $trimmed.EndsWith('"')) {
+        $inner = $trimmed.Substring(1, $trimmed.Length - 2)
+
+        $sb = New-Object System.Text.StringBuilder
+        $i = 0
+        while ($i -lt $inner.Length) {
+            $ch = $inner[$i]
+            if ($ch -ne '\') {
+                $null = $sb.Append($ch)
+                $i++
+                continue
+            }
+
+            $start = $i
+            while ($i -lt $inner.Length -and $inner[$i] -eq '\') {
+                $i++
+            }
+
+            $slashCount = $i - $start
+            $nextChar = if ($i -lt $inner.Length) { $inner[$i] } else { $null }
+
+            $isEscape = $false
+            $escapedChar = $null
+            if ($null -ne $nextChar -and ($slashCount % 2 -eq 1)) {
+                switch ($nextChar) {
+                    'n' { $isEscape = $true; $escapedChar = "`n" }
+                    'r' { $isEscape = $true; $escapedChar = "`r" }
+                    't' { $isEscape = $true; $escapedChar = "`t" }
+                    '"' { $isEscape = $true; $escapedChar = '"' }
+                }
+            }
+
+            $literalSlashPairs = if ($isEscape) { ($slashCount - 1) / 2 } else { $slashCount / 2 }
+            for ($j = 0; $j -lt $literalSlashPairs; $j++) {
+                $null = $sb.Append('\')
+            }
+
+            if ($isEscape) {
+                $null = $sb.Append($escapedChar)
+                $i++
+            }
+            else {
+                if ($slashCount % 2 -eq 1) {
+                    $null = $sb.Append('\')
+                }
+                if ($null -ne $nextChar) {
+                    $null = $sb.Append($nextChar)
+                    $i++
+                }
+            }
+        }
+
+        $result = $sb.ToString()
+        if ($result.Length -eq 0) {
+            return $null
+        }
+
+        return $result
+    }
+
+    if ($trimmed.Length -ge 2 -and $trimmed.StartsWith("'") -and $trimmed.EndsWith("'")) {
+        return $trimmed.Substring(1, $trimmed.Length - 2)
+    }
+
+    return $trimmed
+}
+
+function Import-VsDevEnv
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0, Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [Alias('FullName','PSPath','LiteralPath')]
+        [string] $Path
+    )
+
+    process {
+        if (-not (Test-Path -Path $Path -PathType Leaf)) {
+            throw [System.IO.FileNotFoundException] "$Path not found."
+        }
+
+        $text = [System.IO.File]::ReadAllText($Path)
+        $lines = $text -split "`r?`n"
+
+        $envDelta = [ordered]@{}
+
+        foreach ($line in $lines) {
+            $trimmed = $line.Trim()
+            if ([string]::IsNullOrWhiteSpace($trimmed)) {
+                continue
+            }
+            if ($trimmed.StartsWith('#')) {
+                continue
+            }
+
+            if ($trimmed -notmatch '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$') {
+                continue
+            }
+
+            $name = $Matches[1]
+            $rawValue = $Matches[2]
+            $envDelta[$name] = ConvertFrom-VsDotEnvValue -Value $rawValue
+        }
+
+        $envDelta
+    }
+}
+
 function ConvertTo-VsDotEnv
 {
     [CmdletBinding()]
@@ -127,6 +253,159 @@ function Write-TextFileUtf8NoBom
     [System.IO.File]::WriteAllText($Path, $Content, $encoding)
 }
 
+function Add-TextFileUtf8NoBom
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string] $Path,
+        [Parameter(Mandatory=$true)]
+        [string] $Content
+    )
+
+    $parent = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrEmpty($parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::AppendAllText($Path, $Content, $encoding)
+}
+
+function Remove-EnvAssignments
+{
+    [CmdletBinding()]
+    param(
+        [AllowEmptyCollection()]
+        [AllowNull()]
+        [string[]] $Lines = @(),
+        [Parameter(Mandatory=$true)]
+        [System.Collections.Generic.HashSet[string]] $KeysToRemove
+    )
+
+    foreach ($line in $Lines) {
+        if ($line -match '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=') {
+            $key = $Matches[1]
+            if ($KeysToRemove.Contains($key)) {
+                continue
+            }
+        }
+
+        $line
+    }
+}
+
+function Export-VsDevEnv
+{
+    [CmdletBinding(DefaultParameterSetName='FromParameters')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string] $Path,
+
+        [ValidateSet('Create', 'Update')]
+        [string] $Mode = 'Update',
+
+        [ValidateSet('Full', 'Skip', 'GitHubPath')]
+        [string] $PathMode = 'Full',
+
+        [switch] $PassThru,
+
+        [Parameter(ParameterSetName='FromDelta', Mandatory=$true, ValueFromPipeline=$true)]
+        [System.Collections.IDictionary] $EnvDelta,
+
+        [Parameter(ParameterSetName='FromParameters')]
+        [ValidateSet('x86','x64','arm','arm64')]
+        [string] $Arch = 'x64',
+
+        [Parameter(ParameterSetName='FromParameters')]
+        [ValidateSet('x86','x64')]
+        [string] $HostArch = 'x64',
+
+        [Parameter(ParameterSetName='FromParameters')]
+        [ValidateSet('Desktop','UWP')]
+        [string] $AppPlatform = 'Desktop',
+
+        [Parameter(ParameterSetName='FromParameters')]
+        [string] $WinSdk,
+
+        [Parameter(ParameterSetName='FromParameters')]
+        [switch] $NoExt,
+
+        [Parameter(ParameterSetName='FromParameters')]
+        [switch] $NoLogo,
+
+        [Parameter(ParameterSetName='FromParameters')]
+        [string] $VsInstallPath
+    )
+
+    $baselinePath = $Env:Path
+
+    if ($PSCmdlet.ParameterSetName -eq 'FromParameters') {
+        $EnvDelta = Get-VsDevEnv -Arch:$Arch -HostArch:$HostArch `
+            -AppPlatform:$AppPlatform -WinSdk:$WinSdk `
+            -NoExt:$NoExt -NoLogo:$NoLogo `
+            -VsInstallPath:$VsInstallPath
+    }
+
+    $exportDelta = [ordered]@{}
+    foreach ($entry in $EnvDelta.GetEnumerator()) {
+        $exportDelta[$entry.Key] = $entry.Value
+    }
+
+    if ($PathMode -eq 'Skip') {
+        $null = $exportDelta.Remove('Path')
+        $null = $exportDelta.Remove('PATH')
+    }
+    elseif ($PathMode -eq 'GitHubPath') {
+        $githubPath = $Env:GITHUB_PATH
+        if (-not [string]::IsNullOrEmpty($githubPath) -and $exportDelta.Contains('PATH')) {
+            $newPath = [string] $exportDelta['PATH']
+
+            if (-not [string]::IsNullOrEmpty($baselinePath) -and $newPath.EndsWith($baselinePath, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $prefix = $newPath.Substring(0, $newPath.Length - $baselinePath.Length)
+                $prefix = $prefix.TrimEnd(';')
+                $prefixParts = $prefix -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+                if ($prefixParts.Count -gt 0) {
+                    $content = ($prefixParts -join [System.Environment]::NewLine) + [System.Environment]::NewLine
+                    Add-TextFileUtf8NoBom -Path $githubPath -Content $content
+                    $null = $exportDelta.Remove('PATH')
+                }
+            }
+        }
+    }
+
+    $dotEnvText = ConvertTo-VsDotEnv -EnvDelta $exportDelta
+
+    if ($Mode -eq 'Create' -and (Test-Path -Path $Path -PathType Leaf)) {
+        throw "File already exists: $Path"
+    }
+
+    if ($Mode -eq 'Update' -and (Test-Path -Path $Path -PathType Leaf)) {
+        $existingText = [System.IO.File]::ReadAllText($Path)
+        $existingLines = $existingText -split "`r?`n"
+
+        $keys = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($k in $exportDelta.Keys) { $null = $keys.Add([string] $k) }
+
+        $keptLines = @(Remove-EnvAssignments -Lines $existingLines -KeysToRemove $keys)
+        $keptText = ($keptLines -join [System.Environment]::NewLine).TrimEnd()
+
+        if ($keptText.Length -gt 0) {
+            $keptText += [System.Environment]::NewLine
+        }
+
+        Write-TextFileUtf8NoBom -Path $Path -Content ($keptText + $dotEnvText)
+    }
+    else {
+        Write-TextFileUtf8NoBom -Path $Path -Content $dotEnvText
+    }
+
+    if ($PassThru) {
+        Get-Item -Path $Path
+    }
+}
+
 function Invoke-VsDevCmdSet
 {
     [CmdletBinding()]
@@ -134,7 +413,8 @@ function Invoke-VsDevCmdSet
         [Parameter(Mandatory=$true)]
         [string] $VsDevCmdPath,
         [Parameter(Mandatory=$true)]
-        [string] $VsCmdArgs
+        [string] $VsCmdArgs,
+        [hashtable] $AdditionalEnvironment
     )
 
     $processStartInfo = New-Object System.Diagnostics.ProcessStartInfo
@@ -144,6 +424,20 @@ function Invoke-VsDevCmdSet
     $processStartInfo.RedirectStandardOutput = $true
     $processStartInfo.UseShellExecute = $false
     $processStartInfo.CreateNoWindow = $true
+
+    if ($AdditionalEnvironment) {
+        foreach ($pair in $AdditionalEnvironment.GetEnumerator()) {
+            $key = [string] $pair.Key
+            $value = if ($null -eq $pair.Value) { '' } else { [string] $pair.Value }
+
+            if ($processStartInfo.PSObject.Properties.Name -contains 'Environment') {
+                $processStartInfo.Environment[$key] = $value
+            }
+            else {
+                $processStartInfo.EnvironmentVariables[$key] = $value
+            }
+        }
+    }
 
     $process = New-Object System.Diagnostics.Process
     $process.StartInfo = $processStartInfo
@@ -171,9 +465,7 @@ function Get-VsDevEnv
         [string] $WinSdk,
         [switch] $NoExt,
         [switch] $NoLogo,
-        [string] $VsInstallPath,
-        [switch] $AsDotEnv,
-        [string] $DotEnvPath
+        [string] $VsInstallPath
     )
 
     if ([string]::IsNullOrEmpty($VsInstallPath)) {
@@ -208,10 +500,12 @@ function Get-VsDevEnv
         $VsCmdArgs += " -no_logo"
     }
 
-    $Env:VSCMD_SKIP_SENDTELEMETRY = "1"
-    $Env:VSCMD_BANNER_SHELL_NAME_ALT = "$Arch Developer Shell"
+    $additionalEnv = @{
+        VSCMD_SKIP_SENDTELEMETRY = '1'
+        VSCMD_BANNER_SHELL_NAME_ALT = "$Arch Developer Shell"
+    }
 
-    $vsCmdResult = Invoke-VsDevCmdSet -VsDevCmdPath $VsDevCmdPath -VsCmdArgs $VsCmdArgs
+    $vsCmdResult = Invoke-VsDevCmdSet -VsDevCmdPath $VsDevCmdPath -VsCmdArgs $VsCmdArgs -AdditionalEnvironment $additionalEnv
     $VsCmdOutput = $vsCmdResult.OutputLines
 
     if ($vsCmdResult.ExitCode -ne 0) {
@@ -241,42 +535,124 @@ function Get-VsDevEnv
         }
     }
 
-    if ($AsDotEnv -or $PSBoundParameters.ContainsKey('DotEnvPath')) {
-        $dotEnvText = ConvertTo-VsDotEnv -EnvDelta $VsDevEnv
-
-        if (-not [string]::IsNullOrEmpty($DotEnvPath)) {
-            Write-TextFileUtf8NoBom -Path $DotEnvPath -Content $dotEnvText
-        }
-
-        return $dotEnvText
-    }
-
     $VsDevEnv
 }
 
 function Enter-VsDevShell
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='FromParameters')]
     param(
-        [Parameter(Position=0)]
+        [Parameter(ParameterSetName='FromParameters', Position=0)]
         [ValidateSet('x86','x64','arm','arm64')]
         [string] $Arch = "x64",
+        [Parameter(ParameterSetName='FromParameters')]
         [ValidateSet('x86','x64')]
         [string] $HostArch = "x64",
+        [Parameter(ParameterSetName='FromParameters')]
         [ValidateSet('Desktop','UWP')]
         [string] $AppPlatform = "Desktop",
+        [Parameter(ParameterSetName='FromParameters')]
         [string] $WinSdk,
+        [Parameter(ParameterSetName='FromParameters')]
         [switch] $NoExt,
+        [Parameter(ParameterSetName='FromParameters')]
         [switch] $NoLogo,
-        [string] $VsInstallPath
+        [Parameter(ParameterSetName='FromParameters')]
+        [string] $VsInstallPath,
+
+        [Parameter(ParameterSetName='FromFile', Mandatory=$true, Position=0, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [Alias('Path', 'FullName', 'PSPath', 'LiteralPath')]
+        [string] $EnvFilePath,
+
+        [Parameter(ParameterSetName='FromEnv', Mandatory=$true, ValueFromPipeline=$true)]
+        [System.Collections.IDictionary] $VsDevEnv,
+
+        [switch] $Force
     )
 
-    $VsDevEnv = Get-VsDevEnv -Arch:$Arch -HostArch:$HostArch `
-        -AppPlatform:$AppPlatform -WinSdk:$WinSdk `
-        -NoExt:$NoExt -NoLogo:$NoLogo `
-        -VsInstallPath:$VsInstallPath
+    process {
+        if ($global:VsDevShellState -and -not $Force) {
+            throw "VsDevShell is already active in this session. Call Leave-VsDevShell first (or use -Force to overwrite the saved state)."
+        }
 
-    $VsDevEnv.GetEnumerator() | ForEach-Object {
-        [System.Environment]::SetEnvironmentVariable($_.Key, $_.Value)
+        if ($Force -and $global:VsDevShellState) {
+            Remove-Variable -Scope Global -Name VsDevShellState -ErrorAction SilentlyContinue
+        }
+
+        if ($PSCmdlet.ParameterSetName -eq 'FromParameters') {
+            $VsDevEnv = Get-VsDevEnv -Arch:$Arch -HostArch:$HostArch `
+                -AppPlatform:$AppPlatform -WinSdk:$WinSdk `
+                -NoExt:$NoExt -NoLogo:$NoLogo `
+                -VsInstallPath:$VsInstallPath
+        }
+
+        if ($PSCmdlet.ParameterSetName -eq 'FromFile') {
+            $VsDevEnv = Import-VsDevEnv -Path $EnvFilePath
+        }
+
+        $preEnv = [ordered]@{}
+        foreach ($key in $VsDevEnv.Keys) {
+            $preEnv[$key] = [System.Environment]::GetEnvironmentVariable([string] $key)
+        }
+
+        $global:VsDevShellState = [pscustomobject]@{
+            IsActive = $true
+            EnteredAt = Get-Date
+            PreEnv = $preEnv
+        }
+
+        $VsDevEnv.GetEnumerator() | ForEach-Object {
+            [System.Environment]::SetEnvironmentVariable($_.Key, $_.Value)
+        }
+    }
+}
+
+function Leave-VsDevShell
+{
+    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Medium', DefaultParameterSetName='All')]
+    param(
+        [Parameter(ParameterSetName='FromFile', Mandatory=$true, Position=0, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [Alias('Path', 'FullName', 'PSPath', 'LiteralPath')]
+        [string] $EnvFilePath,
+
+        [switch] $Force
+    )
+
+    process {
+        $state = $global:VsDevShellState
+        if (-not $state -or -not $state.IsActive -or -not $state.PreEnv) {
+            if (-not $Force) {
+                Write-Verbose 'No active VsDevShell session state was found.'
+            }
+            return
+        }
+
+        $keysToRestore = @()
+        if ($PSCmdlet.ParameterSetName -eq 'FromFile') {
+            $fileDelta = Import-VsDevEnv -Path $EnvFilePath
+            $keysToRestore = @($fileDelta.Keys)
+        }
+        else {
+            $keysToRestore = @($state.PreEnv.Keys)
+        }
+
+        foreach ($key in $keysToRestore) {
+            $value = $null
+            if ($state.PreEnv.Contains($key)) {
+                $value = $state.PreEnv[$key]
+            }
+
+            if ($PSCmdlet.ShouldProcess("Env:$key", 'Restore')) {
+                [System.Environment]::SetEnvironmentVariable([string] $key, $value)
+            }
+
+            if ($state.PreEnv.Contains($key)) {
+                $null = $state.PreEnv.Remove($key)
+            }
+        }
+
+        if ($state.PreEnv.Count -eq 0) {
+            Remove-Variable -Scope Global -Name VsDevShellState -ErrorAction SilentlyContinue
+        }
     }
 }

--- a/VsDevShell/VsDevShell.psm1
+++ b/VsDevShell/VsDevShell.psm1
@@ -16,6 +16,18 @@ function Get-VsWherePath
     $VsWherePath
 }
 
+function Invoke-VsWhere
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string] $VsWherePath
+    )
+
+    $VsInstallPath = & $VsWherePath "-latest" "-property" "installationPath"
+    [string] $VsInstallPath
+}
+
 function Get-VsInstallPath
 {
     [CmdletBinding()]
@@ -28,8 +40,7 @@ function Get-VsInstallPath
         throw [System.IO.FileNotFoundException] "vswhere.exe not found."
     }
 
-    $VsInstallPath = & $VsWherePath "-latest" "-property" "installationPath"
-    $VsInstallPath
+    (Invoke-VsWhere -VsWherePath $VsWherePath).Trim()
 }
 
 function Get-VsDevCmdPath
@@ -48,6 +59,104 @@ function Get-VsDevCmdPath
     $VsDevCmdPath
 }
 
+function ConvertTo-VsDotEnvValue
+{
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [string] $Value
+    )
+
+    if ($null -eq $Value) {
+        return '""'
+    }
+
+    $escaped = [string] $Value
+    $escaped = $escaped.Replace('\', '\\')
+    $escaped = $escaped.Replace('"', '\"')
+    $escaped = $escaped.Replace("`r", '\r')
+    $escaped = $escaped.Replace("`n", '\n')
+    $escaped = $escaped.Replace("`t", '\t')
+
+    '"' + $escaped + '"'
+}
+
+function ConvertTo-VsDotEnv
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [System.Collections.IDictionary] $EnvDelta
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+
+    foreach ($entry in $EnvDelta.GetEnumerator()) {
+        $name = [string] $entry.Key
+
+        if ([string]::IsNullOrWhiteSpace($name) -or $name.Contains('=') -or $name -match '\s') {
+            continue
+        }
+
+        $lines.Add(($name + '=' + (ConvertTo-VsDotEnvValue -Value $entry.Value)))
+    }
+
+    $text = $lines -join [System.Environment]::NewLine
+    if ($text.Length -gt 0) {
+        $text += [System.Environment]::NewLine
+    }
+    $text
+}
+
+function Write-TextFileUtf8NoBom
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string] $Path,
+        [Parameter(Mandatory=$true)]
+        [string] $Content
+    )
+
+    $parent = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrEmpty($parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $Content, $encoding)
+}
+
+function Invoke-VsDevCmdSet
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string] $VsDevCmdPath,
+        [Parameter(Mandatory=$true)]
+        [string] $VsCmdArgs
+    )
+
+    $processStartInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $processStartInfo.FileName = "${Env:COMSPEC}"
+    $processStartInfo.Arguments = "/c `"`"$VsDevCmdPath`" $VsCmdArgs && set`""
+    $processStartInfo.WorkingDirectory = Split-Path $VsDevCmdPath
+    $processStartInfo.RedirectStandardOutput = $true
+    $processStartInfo.UseShellExecute = $false
+    $processStartInfo.CreateNoWindow = $true
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $processStartInfo
+    $process.Start() | Out-Null
+    $outputText = $process.StandardOutput.ReadToEnd()
+    $process.WaitForExit()
+
+    [ordered]@{
+        ExitCode = $process.ExitCode
+        OutputLines = ($outputText -split "`r`n")
+    }
+}
+
 function Get-VsDevEnv
 {
     [CmdletBinding()]
@@ -62,7 +171,9 @@ function Get-VsDevEnv
         [string] $WinSdk,
         [switch] $NoExt,
         [switch] $NoLogo,
-        [string] $VsInstallPath
+        [string] $VsInstallPath,
+        [switch] $AsDotEnv,
+        [string] $DotEnvPath
     )
 
     if ([string]::IsNullOrEmpty($VsInstallPath)) {
@@ -100,23 +211,10 @@ function Get-VsDevEnv
     $Env:VSCMD_SKIP_SENDTELEMETRY = "1"
     $Env:VSCMD_BANNER_SHELL_NAME_ALT = "$Arch Developer Shell"
 
-    $processStartInfo = New-Object System.Diagnostics.ProcessStartInfo
-    $processStartInfo.FileName = "${Env:COMSPEC}"
-    $processStartInfo.Arguments = "/c `"`"$VsDevCmdPath`" $VsCmdArgs && set`""
-    $processStartInfo.WorkingDirectory = Split-Path $VsDevCmdPath
-    $processStartInfo.RedirectStandardOutput = $true
-    $processStartInfo.UseShellExecute = $false
-    $processStartInfo.CreateNoWindow = $true
+    $vsCmdResult = Invoke-VsDevCmdSet -VsDevCmdPath $VsDevCmdPath -VsCmdArgs $VsCmdArgs
+    $VsCmdOutput = $vsCmdResult.OutputLines
 
-    $process = New-Object System.Diagnostics.Process
-    $process.StartInfo = $processStartInfo
-    $process.Start() | Out-Null
-    $VsCmdOutput = $process.StandardOutput.ReadToEnd()
-    $process.WaitForExit()
-
-    $VsCmdOutput = $VsCmdOutput -split "`r`n"
-
-    if ($process.ExitCode -ne 0) {
+    if ($vsCmdResult.ExitCode -ne 0) {
         throw "Failed to execute VsDevCmd.bat"
     }
 
@@ -126,13 +224,31 @@ function Get-VsDevEnv
     }
 
     $VsDevEnv = [ordered]@{}
+    $VsCmdNames = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
     foreach ($VsCmdLine in $VsCmdOutput) {
         if ($VsCmdLine.Contains('=')) {
             $Name, $Value = $VsCmdLine -split '=', 2
+            $null = $VsCmdNames.Add($Name)
             if ($PreEnv[$Name] -ne $Value) {
                 $VsDevEnv.Add($Name, $Value)
             }
         }
+    }
+
+    foreach ($name in $PreEnv.Keys) {
+        if (-not $VsCmdNames.Contains($name)) {
+            $VsDevEnv[$name] = $null
+        }
+    }
+
+    if ($AsDotEnv -or $PSBoundParameters.ContainsKey('DotEnvPath')) {
+        $dotEnvText = ConvertTo-VsDotEnv -EnvDelta $VsDevEnv
+
+        if (-not [string]::IsNullOrEmpty($DotEnvPath)) {
+            Write-TextFileUtf8NoBom -Path $DotEnvPath -Content $dotEnvText
+        }
+
+        return $dotEnvText
     }
 
     $VsDevEnv

--- a/skills/vsdevshell/SKILL.md
+++ b/skills/vsdevshell/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: enable-vsdevshell
-description: Use the installed VsDevShell module to enter a Visual Studio Developer Shell environment from PowerShell.
+name: vsdevshell
+description: Enter the Visual Studio Developer environment in the current PowerShell session via the VsDevShell module (MSBuild/CL toolchain env vars).
 ---
 
-# Enable Visual Studio Developer Shell (via VsDevShell module)
+# VsDevShell (Visual Studio Developer Shell)
 
 Use this skill when you need to run Windows build tools that typically only work after a Visual Studio Developer Prompt / `VsDevCmd.bat` has been applied.
 

--- a/skills/vsdevshell/SKILL.md
+++ b/skills/vsdevshell/SKILL.md
@@ -29,14 +29,18 @@ If you need to run any of the following, **enter the VS dev shell first** so PAT
 - Binary inspection & PDB/symbol utilities (varies by installed components): `dumpbin.exe`, `pdbcopy.exe`, `pdbstr.exe`, `symstore.exe`, `symchk.exe`
 - Driver/INF tooling (specialized; requires WDK components): `inf2cat.exe`
 
-If the user’s command references one of these tools (or a build script calls them indirectly), run the “enable” step before running the command.
+If the user’s command references one of these tools (or a build script calls them indirectly), run the “enter dev env” step before running the command.
 
 ## Key idea
 
 `Enter-VsDevShell` updates **process environment variables** (PATH, INCLUDE, LIB, VSINSTALLDIR, etc.) for the **current PowerShell process**.
 
 - Run it in the **same** terminal/session where you will run `msbuild`.
-- In VS Code tool runners, avoid starting a brand-new shell between “enable env” and “build”.
+- In VS Code tool runners, avoid starting a brand-new shell between “enter dev env” and “build”.
+
+To restore the original environment (the values captured when you entered), use:
+
+- `Leave-VsDevShell`
 
 ### Important: one-time per PowerShell process
 
@@ -44,6 +48,7 @@ Treat `Enter-VsDevShell` as a **one-time initialization step per PowerShell proc
 
 - If you start a **fresh** `pwsh`/`powershell.exe` process (new terminal tab, new task invocation, new CI step, etc.) and you need VS build tools, you must call `Enter-VsDevShell` in that process.
 - If you **reuse an existing** PowerShell process where you already called `Enter-VsDevShell`, don’t call it again.
+- If you really need to re-enter without leaving, use `Enter-VsDevShell -Force`.
 - If you need a *different* dev environment (for example a different `-Arch`/`-HostArch`/`-WinSdk`), use a **new PowerShell process** and call `Enter-VsDevShell` there with the new parameters.
 
 ## Prerequisite
@@ -73,8 +78,8 @@ Notes:
 - `-HostArch`: architecture of the machine running the tools
   - Typical x64 Windows host → `-HostArch x64`
   - Typical x86 Windows host → `-HostArch x86`
-  - Windows on ARM host → `-HostArch arm64`
-- `-AppPlatform`: `Desktop` or `UWP` (forwarded to `VsDevCmd.bat` as `-app_platform=`)
+  - Note: currently only `x86`/`x64` are accepted for `-HostArch`.
+- `-AppPlatform`: accepted for compatibility, but currently not used to build `VsDevCmd.bat` arguments.
 - `-WinSdk`: optional Windows SDK version string (only set when the user specifies a required SDK)
 - `-NoExt`, `-NoLogo`: optional switches to reduce startup work/noise
 - `-VsInstallPath`: only set when targeting a specific Visual Studio installation
@@ -117,41 +122,63 @@ If you want to see what would change without modifying your current process envi
 
 - `Get-VsDevEnv -Arch x64 -HostArch x64 | Format-Table -AutoSize`
 
-## Export to a `.env` (dotenv) file
+## Cmdlets and common workflows
 
-If you need to reuse the computed VS dev environment from **non-PowerShell** tooling that can load a dotenv file, you can export the output of `Get-VsDevEnv` as `KEY="VALUE"` lines.
+### Enter / Leave
 
-PowerShell snippet (creates a dotenv file from the env delta):
+- Compute + apply VS dev environment:
+  - `Enter-VsDevShell -Arch x64 -HostArch x64`
+- Restore original values captured at enter time:
+  - `Leave-VsDevShell`
+
+### Export / Import `.env`
+
+Export the computed delta to a standard `.env` file (UTF-8 no BOM):
+
+- `Export-VsDevEnv -Arch x64 -HostArch x64 -Path .\vsdev.env -Mode Update`
+
+Apply a `.env` file in the current session:
+
+- Pipeline form:
+  - `Import-VsDevEnv .\vsdev.env | Enter-VsDevShell`
+- Shortcut:
+  - `Enter-VsDevShell -EnvFilePath .\vsdev.env`
+
+Restore only the keys listed in the file (using the saved pre-enter snapshot):
+
+- `Leave-VsDevShell -EnvFilePath .\vsdev.env`
+
+Fully piped chain (compute → export → import → apply):
 
 ```powershell
-$envDelta = Get-VsDevEnv -Arch x64 -HostArch x64
-
-$dotenvPath = Join-Path $PWD '.vsdevshell.env'
-
-$lines = foreach ($pair in ($envDelta.GetEnumerator() | Sort-Object Key)) {
-  $key = $pair.Key
-  $value = [string]$pair.Value
-
-  # Quote/escape for common dotenv parsers: KEY="..."
-  $escaped = $value.Replace('"', '\"').Replace("`r", '').Replace("`n", '\n')
-  "$key=\"$escaped\""
-}
-
-([System.IO.File]::WriteAllLines(
-  $dotenvPath,
-  $lines,
-  (New-Object System.Text.UTF8Encoding $false) # UTF-8 without BOM
-))
-"Wrote $dotenvPath"
+Get-VsDevEnv -Arch x64 -HostArch x64 |
+  Export-VsDevEnv -Path .\vsdev.env -Mode Update -PassThru |
+  Import-VsDevEnv |
+  Enter-VsDevShell
 ```
 
 Notes:
 
 - This writes the **computed values** (including `PATH`) and will typically **override** whatever values your target process already has.
-- Loading a dotenv file varies by tool/shell. For example, in `bash` you often need `set -a; source ./.vsdevshell.env; set +a` to export the variables to child processes.
+- Loading a dotenv file varies by tool/shell. For example, in `bash` you often need `set -a; source ./vsdev.env; set +a` to export the variables to child processes.
+
+### GitHub Actions (`GITHUB_ENV`)
+
+In GitHub Actions, `$env:GITHUB_ENV` is a standard env file shared across steps.
+Update it so later steps inherit the VS dev environment:
+
+- `Export-VsDevEnv -Arch x64 -HostArch x64 -Path $env:GITHUB_ENV -Mode Update`
+
+If `$env:GITHUB_PATH` is available and you want PATH handled there, use:
+
+- `Export-VsDevEnv -Arch x64 -HostArch x64 -Path $env:GITHUB_ENV -Mode Update -PathMode GitHubPath`
+
+Apply it in the current step/session (optional):
+
+- `Enter-VsDevShell -EnvFilePath $env:GITHUB_ENV`
 
 ## Notes
 
 - Windows only (relies on `%COMSPEC%` and Visual Studio's `VsDevCmd.bat`).
 - If `msbuild` still isn’t available after enabling the environment, the installed Visual Studio workload may be missing MSBuild/VC tools.
-- `AppPlatform` is forwarded to `VsDevCmd.bat`; if a particular VS version rejects it, re-run without `-AppPlatform` (or keep the default `Desktop`).
+- `AppPlatform` is currently accepted but not used to build `VsDevCmd.bat` arguments.

--- a/skills/vsdevshell/SKILL.md
+++ b/skills/vsdevshell/SKILL.md
@@ -40,7 +40,7 @@ If the user’s command references one of these tools (or a build script calls t
 
 To restore the original environment (the values captured when you entered), use:
 
-- `Leave-VsDevShell`
+- `Exit-VsDevShell`
 
 ### Important: one-time per PowerShell process
 
@@ -129,7 +129,7 @@ If you want to see what would change without modifying your current process envi
 - Compute + apply VS dev environment:
   - `Enter-VsDevShell -Arch x64 -HostArch x64`
 - Restore original values captured at enter time:
-  - `Leave-VsDevShell`
+  - `Exit-VsDevShell`
 
 ### Export / Import `.env`
 
@@ -146,7 +146,7 @@ Apply a `.env` file in the current session:
 
 Restore only the keys listed in the file (using the saved pre-enter snapshot):
 
-- `Leave-VsDevShell -EnvFilePath .\vsdev.env`
+- `Exit-VsDevShell -EnvFilePath .\vsdev.env`
 
 Fully piped chain (compute → export → import → apply):
 

--- a/tests/VsDevShell.Tests.ps1
+++ b/tests/VsDevShell.Tests.ps1
@@ -276,7 +276,7 @@ Describe 'VsDevShell' {
             }
 
             AfterEach {
-                Leave-VsDevShell -Force
+                Exit-VsDevShell -Force
                 Remove-Variable -Scope Global -Name VsDevShellState -ErrorAction SilentlyContinue
             }
 
@@ -301,7 +301,7 @@ Describe 'VsDevShell' {
                     [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -BeNullOrEmpty
                 }
                 finally {
-                    Leave-VsDevShell -Force
+                    Exit-VsDevShell -Force
                     [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
                     [System.Environment]::SetEnvironmentVariable('REMOVED', $oldRemoved)
                 }
@@ -327,7 +327,7 @@ Describe 'VsDevShell' {
                     [System.Environment]::GetEnvironmentVariable('MULTI') | Should -Be "line1`nline2"
                 }
                 finally {
-                    Leave-VsDevShell -Force
+                    Exit-VsDevShell -Force
                     [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
                     [System.Environment]::SetEnvironmentVariable('MULTI', $oldMulti)
                 }
@@ -353,7 +353,7 @@ Describe 'VsDevShell' {
                     [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -BeNullOrEmpty
                 }
                 finally {
-                    Leave-VsDevShell -Force
+                    Exit-VsDevShell -Force
                     [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
                     [System.Environment]::SetEnvironmentVariable('REMOVED', $oldRemoved)
                 }
@@ -375,7 +375,7 @@ Describe 'VsDevShell' {
                     [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'frompipeline'
                 }
                 finally {
-                    Leave-VsDevShell -Force
+                    Exit-VsDevShell -Force
                     [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
                 }
             }
@@ -412,7 +412,7 @@ Describe 'VsDevShell' {
                     }
 
                     # Clear saved session state so the piped Enter can run
-                    Leave-VsDevShell
+                    Exit-VsDevShell
 
                     # Reset baseline
                     [System.Environment]::SetEnvironmentVariable('FOO', 'before')
@@ -433,14 +433,14 @@ Describe 'VsDevShell' {
                     }
                 }
                 finally {
-                    Leave-VsDevShell -Force
+                    Exit-VsDevShell -Force
                     foreach ($k in $keys) {
                         [System.Environment]::SetEnvironmentVariable($k, $saved[$k])
                     }
                 }
             }
 
-            It 'Can restore the pre-enter environment via Leave-VsDevShell' {
+            It 'Can restore the pre-enter environment via Exit-VsDevShell' {
                 $oldFoo = [System.Environment]::GetEnvironmentVariable('FOO')
                 $oldRemoved = [System.Environment]::GetEnvironmentVariable('REMOVED')
 
@@ -460,7 +460,7 @@ Describe 'VsDevShell' {
                     [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -BeNullOrEmpty
                     ($null -ne $global:VsDevShellState) | Should -BeTrue
 
-                    Leave-VsDevShell
+                    Exit-VsDevShell
                     [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'before'
                     [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -Be 'x'
                     ($null -eq $global:VsDevShellState) | Should -BeTrue
@@ -472,7 +472,7 @@ Describe 'VsDevShell' {
                 }
             }
 
-            It 'Can restore using Leave-VsDevShell -EnvFilePath (symmetry with Enter -EnvFilePath)' {
+            It 'Can restore using Exit-VsDevShell -EnvFilePath (symmetry with Enter -EnvFilePath)' {
                 $path = Join-Path $TestDrive 'in/leave.env'
                 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
                 Set-Content -Encoding UTF8 -Path $path -Value @(
@@ -490,18 +490,18 @@ Describe 'VsDevShell' {
                     [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'fromfile'
                     [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -BeNullOrEmpty
 
-                    Leave-VsDevShell -EnvFilePath $path
+                    Exit-VsDevShell -EnvFilePath $path
                     [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'before'
                     [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -Be 'x'
                 }
                 finally {
-                    Leave-VsDevShell -Force
+                    Exit-VsDevShell -Force
                     [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
                     [System.Environment]::SetEnvironmentVariable('REMOVED', $oldRemoved)
                 }
             }
 
-            It 'Binds Leave-VsDevShell EnvFilePath from pipeline property (FileInfo.FullName)' {
+            It 'Binds Exit-VsDevShell EnvFilePath from pipeline property (FileInfo.FullName)' {
                 $path = Join-Path $TestDrive 'in/leave2.env'
                 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
                 Set-Content -Encoding UTF8 -Path $path -Value @(
@@ -514,11 +514,11 @@ Describe 'VsDevShell' {
                     Enter-VsDevShell -EnvFilePath $path
                     [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'fromfile'
 
-                    Get-Item -Path $path | Leave-VsDevShell
+                    Get-Item -Path $path | Exit-VsDevShell
                     [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'before'
                 }
                 finally {
-                    Leave-VsDevShell -Force
+                    Exit-VsDevShell -Force
                     [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
                 }
             }
@@ -550,11 +550,11 @@ Describe 'VsDevShell' {
                     Enter-VsDevShell -EnvFilePath $path
                     [System.Environment]::GetEnvironmentVariable($sentinelKey) | Should -Be 'after'
 
-                    Leave-VsDevShell -EnvFilePath $path
+                    Exit-VsDevShell -EnvFilePath $path
                     [System.Environment]::GetEnvironmentVariable($sentinelKey) | Should -Be 'before'
                 }
                 finally {
-                    Leave-VsDevShell -Force
+                    Exit-VsDevShell -Force
                     [System.Environment]::SetEnvironmentVariable($sentinelKey, $oldSentinel)
                 }
             }

--- a/tests/VsDevShell.Tests.ps1
+++ b/tests/VsDevShell.Tests.ps1
@@ -1,0 +1,230 @@
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$moduleManifest = Join-Path $repoRoot 'VsDevShell/VsDevShell.psd1'
+
+Import-Module $moduleManifest -Force | Out-Null
+
+Describe 'VsDevShell' {
+    InModuleScope VsDevShell {
+        Context 'ConvertTo-VsDotEnvValue' {
+            It 'Quotes null as empty string' {
+                ConvertTo-VsDotEnvValue -Value $null | Should -Be '""'
+            }
+
+            It 'Escapes backslashes, quotes, and newlines' {
+                $value = "C:\path\`"quoted`"`nline2"
+                $expected = '"C:\\path\\\"quoted\"' + '\n' + 'line2"'
+                ConvertTo-VsDotEnvValue -Value $value | Should -Be $expected
+            }
+        }
+
+        Context 'ConvertTo-VsDotEnv' {
+            It 'Skips invalid keys and ends with a newline' {
+                $delta = [ordered]@{
+                    'GOOD' = '1'
+                    'BAD KEY' = '2'
+                    'BAD=KEY' = '3'
+                }
+
+                $text = ConvertTo-VsDotEnv -EnvDelta $delta
+
+                $text | Should -Match '(?m)^GOOD="1"\r?$'
+                $text | Should -Not -Match "BAD KEY="
+                $text | Should -Not -Match "BAD=KEY="
+                $text | Should -Match '(\r\n|\n)$'
+            }
+
+            It 'Returns empty string for an empty delta' {
+                ConvertTo-VsDotEnv -EnvDelta ([ordered]@{}) | Should -Be ''
+            }
+        }
+
+        Context 'Get-VsInstallPath' {
+            It 'Throws when vswhere.exe is missing' {
+                Mock Get-VsWherePath { 'C:\missing\vswhere.exe' }
+                Mock Test-Path { $false } -ParameterFilter { $Path -eq 'C:\missing\vswhere.exe' -and $PathType -eq 'Leaf' }
+
+                { Get-VsInstallPath } | Should -Throw
+            }
+
+            It 'Trims the vswhere output' {
+                Mock Get-VsWherePath { 'C:\ok\vswhere.exe' }
+                Mock Test-Path { $true } -ParameterFilter { $Path -eq 'C:\ok\vswhere.exe' -and $PathType -eq 'Leaf' }
+                Mock Invoke-VsWhere { "C:\VS`r`n" }
+
+                Get-VsInstallPath | Should -Be 'C:\VS'
+            }
+        }
+
+        Context 'Get-VsDevEnv (unit, mocked execution)' {
+            BeforeEach {
+                Mock Get-VsDevCmdPath { 'C:\VS\Common7\Tools\VsDevCmd.bat' }
+
+                Mock Test-Path { $true } -ParameterFilter { $Path -eq 'C:\VS' -and $PathType -eq 'Container' }
+                Mock Test-Path { $true } -ParameterFilter { $Path -eq 'C:\VS\Common7\Tools\VsDevCmd.bat' -and $PathType -eq 'Leaf' }
+
+                Mock Get-ChildItem {
+                    @(
+                        [pscustomobject]@{ Name = 'FOO'; Value = 'before' },
+                        [pscustomobject]@{ Name = 'UNCHANGED'; Value = 'same' },
+                        [pscustomobject]@{ Name = 'REMOVED'; Value = 'x' }
+                    )
+                } -ParameterFilter { $Path -eq 'env:' }
+
+                Mock Invoke-VsDevCmdSet {
+                    [ordered]@{
+                        ExitCode = 0
+                        OutputLines = @(
+                            'FOO=after',
+                            'UNCHANGED=same'
+                        )
+                    }
+                }
+            }
+
+            It 'Returns only changed and removed variables' {
+                $delta = Get-VsDevEnv -VsInstallPath 'C:\VS'
+
+                $delta.Keys | Should -Contain 'FOO'
+                $delta['FOO'] | Should -Be 'after'
+
+                $delta.Keys | Should -Contain 'REMOVED'
+                $delta['REMOVED'] | Should -BeNullOrEmpty
+
+                $delta.Keys | Should -Not -Contain 'UNCHANGED'
+            }
+
+            It 'Includes new variables set by VsDevCmd' {
+                Mock Get-ChildItem {
+                    @(
+                        [pscustomobject]@{ Name = 'FOO'; Value = 'before' }
+                    )
+                } -ParameterFilter { $Path -eq 'env:' }
+
+                Mock Invoke-VsDevCmdSet {
+                    [ordered]@{
+                        ExitCode = 0
+                        OutputLines = @(
+                            'FOO=before',
+                            'NEWVAR=new'
+                        )
+                    }
+                }
+
+                $delta = Get-VsDevEnv -VsInstallPath 'C:\VS'
+                $delta.Keys | Should -Contain 'NEWVAR'
+                $delta['NEWVAR'] | Should -Be 'new'
+                $delta.Keys | Should -Not -Contain 'FOO'
+            }
+
+            It 'Ignores lines without "=" and preserves values containing "="' {
+                Mock Invoke-VsDevCmdSet {
+                    [ordered]@{
+                        ExitCode = 0
+                        OutputLines = @(
+                            'THIS IS NOT AN ENV LINE',
+                            'HAS_EQUALS=a=b=c'
+                        )
+                    }
+                }
+
+                $delta = Get-VsDevEnv -VsInstallPath 'C:\VS'
+                $delta['HAS_EQUALS'] | Should -Be 'a=b=c'
+            }
+
+            It 'Outputs dotenv text when -AsDotEnv is used' {
+                $text = Get-VsDevEnv -VsInstallPath 'C:\VS' -AsDotEnv
+
+                $text | Should -BeOfType [string]
+                $text | Should -Match '(?m)^FOO="after"\r?$'
+                $text | Should -Match '(?m)^REMOVED=""\r?$'
+                $text | Should -Not -Match '(?m)^UNCHANGED='
+            }
+
+            It 'Writes a UTF-8 (no BOM) .env file when -DotEnvPath is used' {
+                $path = Join-Path $TestDrive 'out/vs.env'
+                $text = Get-VsDevEnv -VsInstallPath 'C:\VS' -DotEnvPath $path
+
+                ([System.IO.File]::Exists($path)) | Should -BeTrue
+                (Get-Content -Path $path -Raw) | Should -Be $text
+
+                $bytes = [System.IO.File]::ReadAllBytes($path)
+                if ($bytes.Length -ge 3) {
+                    # Ensure there is no UTF-8 BOM (EF BB BF)
+                    ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) | Should -BeFalse
+                }
+            }
+
+            It 'Builds VsDevCmd arguments from parameters' {
+                Mock Invoke-VsDevCmdSet {
+                    [ordered]@{ ExitCode = 0; OutputLines = @('FOO=after') }
+                }
+
+                $null = Get-VsDevEnv -VsInstallPath 'C:\VS' -Arch ARM64 -HostArch X64 -WinSdk '10.0.0.0' -NoExt -NoLogo
+
+                Assert-MockCalled Invoke-VsDevCmdSet -Times 1 -ParameterFilter {
+                    $VsCmdArgs -like '*-arch=arm64*' -and
+                    $VsCmdArgs -like '*-host_arch=x64*' -and
+                    $VsCmdArgs -like '*-winsdk=10.0.0.0*' -and
+                    $VsCmdArgs -like '*-no_ext*' -and
+                    $VsCmdArgs -like '*-no_logo*'
+                }
+            }
+        }
+
+        Context 'Get-VsDevEnv (unit, error paths)' {
+            BeforeEach {
+                Mock Get-VsDevCmdPath { 'C:\VS\Common7\Tools\VsDevCmd.bat' }
+            }
+
+            It 'Throws if the VS install path does not exist' {
+                Mock Test-Path { $false } -ParameterFilter { $Path -eq 'C:\VS' -and $PathType -eq 'Container' }
+                { Get-VsDevEnv -VsInstallPath 'C:\VS' } | Should -Throw
+            }
+
+            It 'Throws if VsDevCmd.bat does not exist' {
+                Mock Test-Path { $true } -ParameterFilter { $Path -eq 'C:\VS' -and $PathType -eq 'Container' }
+                Mock Test-Path { $false } -ParameterFilter { $Path -eq 'C:\VS\Common7\Tools\VsDevCmd.bat' -and $PathType -eq 'Leaf' }
+                { Get-VsDevEnv -VsInstallPath 'C:\VS' } | Should -Throw
+            }
+
+            It 'Throws if VsDevCmd.bat returns a non-zero exit code' {
+                Mock Test-Path { $true } -ParameterFilter { $Path -eq 'C:\VS' -and $PathType -eq 'Container' }
+                Mock Test-Path { $true } -ParameterFilter { $Path -eq 'C:\VS\Common7\Tools\VsDevCmd.bat' -and $PathType -eq 'Leaf' }
+                Mock Get-ChildItem { @() } -ParameterFilter { $Path -eq 'env:' }
+                Mock Invoke-VsDevCmdSet { [ordered]@{ ExitCode = 1; OutputLines = @() } }
+
+                { Get-VsDevEnv -VsInstallPath 'C:\VS' } | Should -Throw
+            }
+        }
+
+        Context 'Enter-VsDevShell (unit)' {
+            It 'Applies values and removes variables when value is $null' {
+                $oldFoo = [System.Environment]::GetEnvironmentVariable('FOO')
+                $oldRemoved = [System.Environment]::GetEnvironmentVariable('REMOVED')
+
+                try {
+                    [System.Environment]::SetEnvironmentVariable('FOO', 'before')
+                    [System.Environment]::SetEnvironmentVariable('REMOVED', 'x')
+
+                    Mock Get-VsDevEnv {
+                        [ordered]@{
+                            FOO = 'after'
+                            REMOVED = $null
+                        }
+                    }
+
+                    Enter-VsDevShell -VsInstallPath 'C:\VS'
+
+                    [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'after'
+                    [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -BeNullOrEmpty
+                }
+                finally {
+                    [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
+                    [System.Environment]::SetEnvironmentVariable('REMOVED', $oldRemoved)
+                }
+            }
+        }
+    }
+}

--- a/tests/VsDevShell.Tests.ps1
+++ b/tests/VsDevShell.Tests.ps1
@@ -30,8 +30,8 @@ Describe 'VsDevShell' {
                 $text = ConvertTo-VsDotEnv -EnvDelta $delta
 
                 $text | Should -Match '(?m)^GOOD="1"\r?$'
-                $text | Should -Not -Match "BAD KEY="
-                $text | Should -Not -Match "BAD=KEY="
+                $text | Should -Not -Match 'BAD KEY='
+                $text | Should -Not -Match 'BAD=KEY='
                 $text | Should -Match '(\r\n|\n)$'
             }
 
@@ -133,29 +133,6 @@ Describe 'VsDevShell' {
                 $delta['HAS_EQUALS'] | Should -Be 'a=b=c'
             }
 
-            It 'Outputs dotenv text when -AsDotEnv is used' {
-                $text = Get-VsDevEnv -VsInstallPath 'C:\VS' -AsDotEnv
-
-                $text | Should -BeOfType [string]
-                $text | Should -Match '(?m)^FOO="after"\r?$'
-                $text | Should -Match '(?m)^REMOVED=""\r?$'
-                $text | Should -Not -Match '(?m)^UNCHANGED='
-            }
-
-            It 'Writes a UTF-8 (no BOM) .env file when -DotEnvPath is used' {
-                $path = Join-Path $TestDrive 'out/vs.env'
-                $text = Get-VsDevEnv -VsInstallPath 'C:\VS' -DotEnvPath $path
-
-                ([System.IO.File]::Exists($path)) | Should -BeTrue
-                (Get-Content -Path $path -Raw) | Should -Be $text
-
-                $bytes = [System.IO.File]::ReadAllBytes($path)
-                if ($bytes.Length -ge 3) {
-                    # Ensure there is no UTF-8 BOM (EF BB BF)
-                    ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) | Should -BeFalse
-                }
-            }
-
             It 'Builds VsDevCmd arguments from parameters' {
                 Mock Invoke-VsDevCmdSet {
                     [ordered]@{ ExitCode = 0; OutputLines = @('FOO=after') }
@@ -199,7 +176,110 @@ Describe 'VsDevShell' {
             }
         }
 
+        Context 'Export-VsDevEnv (unit)' {
+            It 'Creates a new .env file from a provided delta' {
+                $path = Join-Path $TestDrive 'out/vs.env'
+                $delta = [ordered]@{ FOO = 'bar' }
+
+                Export-VsDevEnv -Path $path -Mode Create -EnvDelta $delta
+                (Get-Content -Path $path -Raw) | Should -Match '(?m)^FOO="bar"\r?$'
+
+                $bytes = [System.IO.File]::ReadAllBytes($path)
+                if ($bytes.Length -ge 3) {
+                    ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) | Should -BeFalse
+                }
+            }
+
+            It 'Updates an existing .env file by replacing keys and preserving other lines' {
+                $path = Join-Path $TestDrive 'out/vs.env'
+                New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
+                Set-Content -Encoding UTF8 -Path $path -Value @(
+                    '# keep comment',
+                    'KEEP=1',
+                    'FOO="old"'
+                )
+
+                $delta = [ordered]@{ FOO = 'new'; BAR = '2' }
+                Export-VsDevEnv -Path $path -Mode Update -EnvDelta $delta
+
+                $content = Get-Content -Path $path -Raw
+                $content | Should -Match '(?m)^# keep comment\r?$'
+                $content | Should -Match '(?m)^KEEP=1\r?$'
+                $content | Should -Not -Match '(?m)^FOO="old"\r?$'
+                $content | Should -Match '(?m)^FOO="new"\r?$'
+                $content | Should -Match '(?m)^BAR="2"\r?$'
+
+                ([regex]::Matches($content, '(?m)^FOO=')).Count | Should -Be 1
+            }
+
+            It 'Throws in Create mode when the file already exists' {
+                $path = Join-Path $TestDrive 'out/vs.env'
+                New-Item -ItemType File -Force -Path $path | Out-Null
+
+                { Export-VsDevEnv -Path $path -Mode Create -EnvDelta ([ordered]@{ A = '1' }) } | Should -Throw
+            }
+        }
+
+        Context 'Import-VsDevEnv' {
+            It 'Parses basic KEY=VALUE entries and ignores comments/blank lines' {
+                $path = Join-Path $TestDrive 'in/basic.env'
+                New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
+                Set-Content -Encoding UTF8 -Path $path -Value @(
+                    '# comment',
+                    '',
+                    'A=1',
+                    'B="two"'
+                )
+
+                $delta = Import-VsDevEnv -Path $path
+                $delta['A'] | Should -Be '1'
+                $delta['B'] | Should -Be 'two'
+            }
+
+            It 'Unescapes exported sequences in double-quoted values' {
+                $path = Join-Path $TestDrive 'in/esc.env'
+                New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
+                Set-Content -Encoding UTF8 -Path $path -Value @(
+                    'Q="a\"b"',
+                    'P="C:\\temp"',
+                    'N="line1\nline2"',
+                    'T="a\tb"'
+                )
+
+                $delta = Import-VsDevEnv -Path $path
+                    $delta['Q'] | Should -Be 'a"b'
+                $delta['P'] | Should -Be 'C:\temp'
+                $delta['N'] | Should -Be "line1`nline2"
+                $delta['T'] | Should -Be "a`tb"
+            }
+
+            It 'Treats NAME="" as $null (unset convention)' {
+                $path = Join-Path $TestDrive 'in/unset.env'
+                New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
+                Set-Content -Encoding UTF8 -Path $path -Value @(
+                    'UNSET=""'
+                )
+
+                $delta = Import-VsDevEnv -Path $path
+                $delta['UNSET'] | Should -BeNullOrEmpty
+                ($null -eq $delta['UNSET']) | Should -BeTrue
+            }
+
+            It 'Throws when the file does not exist' {
+                { Import-VsDevEnv -Path (Join-Path $TestDrive 'nope.env') } | Should -Throw
+            }
+        }
+
         Context 'Enter-VsDevShell (unit)' {
+            BeforeEach {
+                Remove-Variable -Scope Global -Name VsDevShellState -ErrorAction SilentlyContinue
+            }
+
+            AfterEach {
+                Leave-VsDevShell -Force
+                Remove-Variable -Scope Global -Name VsDevShellState -ErrorAction SilentlyContinue
+            }
+
             It 'Applies values and removes variables when value is $null' {
                 $oldFoo = [System.Environment]::GetEnvironmentVariable('FOO')
                 $oldRemoved = [System.Environment]::GetEnvironmentVariable('REMOVED')
@@ -221,8 +301,261 @@ Describe 'VsDevShell' {
                     [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -BeNullOrEmpty
                 }
                 finally {
+                    Leave-VsDevShell -Force
                     [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
                     [System.Environment]::SetEnvironmentVariable('REMOVED', $oldRemoved)
+                }
+            }
+
+            It 'Accepts a VsDevEnv object from the pipeline' {
+                $path = Join-Path $TestDrive 'in/vs.env'
+                New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
+                Set-Content -Encoding UTF8 -Path $path -Value @(
+                    'FOO="pipe"',
+                    'MULTI="line1\nline2"'
+                )
+
+                $oldFoo = [System.Environment]::GetEnvironmentVariable('FOO')
+                $oldMulti = [System.Environment]::GetEnvironmentVariable('MULTI')
+                try {
+                    [System.Environment]::SetEnvironmentVariable('FOO', $null)
+                    [System.Environment]::SetEnvironmentVariable('MULTI', $null)
+
+                    Import-VsDevEnv -Path $path | Enter-VsDevShell
+
+                    [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'pipe'
+                    [System.Environment]::GetEnvironmentVariable('MULTI') | Should -Be "line1`nline2"
+                }
+                finally {
+                    Leave-VsDevShell -Force
+                    [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
+                    [System.Environment]::SetEnvironmentVariable('MULTI', $oldMulti)
+                }
+            }
+
+            It 'Accepts an env file path (standard .env / GITHUB_ENV style)' {
+                $path = Join-Path $TestDrive 'in/github.env'
+                New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
+                Set-Content -Encoding UTF8 -Path $path -Value @(
+                    'FOO=fromfile',
+                    'REMOVED=""'
+                )
+
+                $oldFoo = [System.Environment]::GetEnvironmentVariable('FOO')
+                $oldRemoved = [System.Environment]::GetEnvironmentVariable('REMOVED')
+                try {
+                    [System.Environment]::SetEnvironmentVariable('FOO', $null)
+                    [System.Environment]::SetEnvironmentVariable('REMOVED', 'x')
+
+                    Enter-VsDevShell -EnvFilePath $path
+
+                    [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'fromfile'
+                    [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -BeNullOrEmpty
+                }
+                finally {
+                    Leave-VsDevShell -Force
+                    [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
+                    [System.Environment]::SetEnvironmentVariable('REMOVED', $oldRemoved)
+                }
+            }
+
+            It 'Binds EnvFilePath from pipeline property (FileInfo.FullName)' {
+                $path = Join-Path $TestDrive 'in/github2.env'
+                New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
+                Set-Content -Encoding UTF8 -Path $path -Value @(
+                    'FOO=frompipeline'
+                )
+
+                $oldFoo = [System.Environment]::GetEnvironmentVariable('FOO')
+                try {
+                    [System.Environment]::SetEnvironmentVariable('FOO', $null)
+
+                    Get-Item -Path $path | Enter-VsDevShell
+
+                    [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'frompipeline'
+                }
+                finally {
+                    Leave-VsDevShell -Force
+                    [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
+                }
+            }
+
+            It 'Matches direct Enter-VsDevShell when using Get|Export|Import|Enter pipeline' {
+                $keys = @('FOO','REMOVED','MULTI','PATH','KEEP')
+                $saved = @{}
+                foreach ($k in $keys) {
+                    $saved[$k] = [System.Environment]::GetEnvironmentVariable($k)
+                }
+
+                $delta = [ordered]@{
+                    FOO = 'after'
+                    REMOVED = $null
+                    MULTI = "line1`nline2"
+                    PATH = 'C:\A;C:\B'
+                }
+
+                try {
+                    # Establish a known baseline
+                    [System.Environment]::SetEnvironmentVariable('FOO', 'before')
+                    [System.Environment]::SetEnvironmentVariable('REMOVED', 'x')
+                    [System.Environment]::SetEnvironmentVariable('MULTI', 'old')
+                    [System.Environment]::SetEnvironmentVariable('PATH', 'C:\Z')
+                    [System.Environment]::SetEnvironmentVariable('KEEP', 'keep')
+
+                    Mock Get-VsDevEnv { $delta }
+
+                    # Direct apply
+                    Enter-VsDevShell -VsInstallPath 'C:\VS'
+                    $direct = @{}
+                    foreach ($k in $keys) {
+                        $direct[$k] = [System.Environment]::GetEnvironmentVariable($k)
+                    }
+
+                    # Clear saved session state so the piped Enter can run
+                    Leave-VsDevShell
+
+                    # Reset baseline
+                    [System.Environment]::SetEnvironmentVariable('FOO', 'before')
+                    [System.Environment]::SetEnvironmentVariable('REMOVED', 'x')
+                    [System.Environment]::SetEnvironmentVariable('MULTI', 'old')
+                    [System.Environment]::SetEnvironmentVariable('PATH', 'C:\Z')
+                    [System.Environment]::SetEnvironmentVariable('KEEP', 'keep')
+
+                    # Chain: Get -> Export (via pipeline) -> Import -> Enter (via pipeline)
+                    $outPath = Join-Path $TestDrive 'out/chain.env'
+                    Get-VsDevEnv -VsInstallPath 'C:\VS' |
+                        Export-VsDevEnv -Path $outPath -Mode Create -PassThru |
+                        Import-VsDevEnv |
+                        Enter-VsDevShell
+
+                    foreach ($k in $keys) {
+                        [System.Environment]::GetEnvironmentVariable($k) | Should -Be $direct[$k]
+                    }
+                }
+                finally {
+                    Leave-VsDevShell -Force
+                    foreach ($k in $keys) {
+                        [System.Environment]::SetEnvironmentVariable($k, $saved[$k])
+                    }
+                }
+            }
+
+            It 'Can restore the pre-enter environment via Leave-VsDevShell' {
+                $oldFoo = [System.Environment]::GetEnvironmentVariable('FOO')
+                $oldRemoved = [System.Environment]::GetEnvironmentVariable('REMOVED')
+
+                try {
+                    [System.Environment]::SetEnvironmentVariable('FOO', 'before')
+                    [System.Environment]::SetEnvironmentVariable('REMOVED', 'x')
+
+                    Mock Get-VsDevEnv {
+                        [ordered]@{
+                            FOO = 'after'
+                            REMOVED = $null
+                        }
+                    }
+
+                    Enter-VsDevShell -VsInstallPath 'C:\VS'
+                    [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'after'
+                    [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -BeNullOrEmpty
+                    ($null -ne $global:VsDevShellState) | Should -BeTrue
+
+                    Leave-VsDevShell
+                    [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'before'
+                    [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -Be 'x'
+                    ($null -eq $global:VsDevShellState) | Should -BeTrue
+                }
+                finally {
+                    [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
+                    [System.Environment]::SetEnvironmentVariable('REMOVED', $oldRemoved)
+                    Remove-Variable -Scope Global -Name VsDevShellState -ErrorAction SilentlyContinue
+                }
+            }
+
+            It 'Can restore using Leave-VsDevShell -EnvFilePath (symmetry with Enter -EnvFilePath)' {
+                $path = Join-Path $TestDrive 'in/leave.env'
+                New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
+                Set-Content -Encoding UTF8 -Path $path -Value @(
+                    'FOO=fromfile',
+                    'REMOVED=""'
+                )
+
+                $oldFoo = [System.Environment]::GetEnvironmentVariable('FOO')
+                $oldRemoved = [System.Environment]::GetEnvironmentVariable('REMOVED')
+                try {
+                    [System.Environment]::SetEnvironmentVariable('FOO', 'before')
+                    [System.Environment]::SetEnvironmentVariable('REMOVED', 'x')
+
+                    Enter-VsDevShell -EnvFilePath $path
+                    [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'fromfile'
+                    [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -BeNullOrEmpty
+
+                    Leave-VsDevShell -EnvFilePath $path
+                    [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'before'
+                    [System.Environment]::GetEnvironmentVariable('REMOVED') | Should -Be 'x'
+                }
+                finally {
+                    Leave-VsDevShell -Force
+                    [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
+                    [System.Environment]::SetEnvironmentVariable('REMOVED', $oldRemoved)
+                }
+            }
+
+            It 'Binds Leave-VsDevShell EnvFilePath from pipeline property (FileInfo.FullName)' {
+                $path = Join-Path $TestDrive 'in/leave2.env'
+                New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
+                Set-Content -Encoding UTF8 -Path $path -Value @(
+                    'FOO=fromfile'
+                )
+
+                $oldFoo = [System.Environment]::GetEnvironmentVariable('FOO')
+                try {
+                    [System.Environment]::SetEnvironmentVariable('FOO', 'before')
+                    Enter-VsDevShell -EnvFilePath $path
+                    [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'fromfile'
+
+                    Get-Item -Path $path | Leave-VsDevShell
+                    [System.Environment]::GetEnvironmentVariable('FOO') | Should -Be 'before'
+                }
+                finally {
+                    Leave-VsDevShell -Force
+                    [System.Environment]::SetEnvironmentVariable('FOO', $oldFoo)
+                }
+            }
+
+            It 'Can round-trip using a full environment .env file export snippet' {
+                $path = Join-Path $TestDrive 'in/full.env'
+                New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
+
+                $sentinelKey = 'VSDEVSHELL_TEST_FOO'
+                $oldSentinel = [System.Environment]::GetEnvironmentVariable($sentinelKey)
+
+                try {
+                    [System.Environment]::SetEnvironmentVariable($sentinelKey, 'before')
+
+                    # Simple snippet: export the current process environment to a standard .env file (UTF-8 no BOM)
+                    $lines = foreach ($item in (Get-ChildItem Env: | Sort-Object Name)) {
+                        $name = [string] $item.Name
+                        $value = [string] $item.Value
+                        "$name=$(ConvertTo-VsDotEnvValue -Value $value)"
+                    }
+
+                    # Override the sentinel at the end (last assignment wins when importing)
+                    $lines += "$sentinelKey=$(ConvertTo-VsDotEnvValue -Value 'after')"
+
+                    $content = ($lines -join [System.Environment]::NewLine) + [System.Environment]::NewLine
+                    $encoding = New-Object System.Text.UTF8Encoding($false)
+                    [System.IO.File]::WriteAllText($path, $content, $encoding)
+
+                    Enter-VsDevShell -EnvFilePath $path
+                    [System.Environment]::GetEnvironmentVariable($sentinelKey) | Should -Be 'after'
+
+                    Leave-VsDevShell -EnvFilePath $path
+                    [System.Environment]::GetEnvironmentVariable($sentinelKey) | Should -Be 'before'
+                }
+                finally {
+                    Leave-VsDevShell -Force
+                    [System.Environment]::SetEnvironmentVariable($sentinelKey, $oldSentinel)
                 }
             }
         }


### PR DESCRIPTION
Renames the unapproved-verb cmdlet Leave-VsDevShell to the approved-verb Exit-VsDevShell and updates manifest, docs, and Pester tests accordingly.